### PR TITLE
Truncate theme name to 50 chars

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 const normalizeThemeName = function normalizeShopifyThemeName(name) {
-   // Remove "refs/heads/" from start of string
-  return name.replace(/^refs\/heads\//g, '')
+   // - remove "refs/heads/" from start of string
+   // - truncate to 50 chars as there is a limitation in the Shopify theme name length
+  return name.replace(/^refs\/heads\//g, '').substr(0, 50);
 };
 
 module.exports = {


### PR DESCRIPTION
Truncate to 50 chars as there is a limitation in the Shopigy theme name length